### PR TITLE
http,oauth: write X-User-Id on auth check responses

### DIFF
--- a/login.go
+++ b/login.go
@@ -40,6 +40,7 @@ func checkLogin(logger log.Logger, auth authable, userService userRepository) ht
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+		w.Header().Set("X-User-Id", userId)
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/oauth.go
+++ b/oauth.go
@@ -113,11 +113,16 @@ func (o *oauth) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// rememberingWriter is a http.ResponseWriter that knows when its headers
+// have been written. This is non-idempotent according to http.ResponseWriter,
+// but there's no good way to inspect if that's happened yet.
 type rememberingWriter struct {
 	http.ResponseWriter
 	statusCode int
 }
 
+// WriteHeader intecepts the embedded WriteHeader call to record what
+// status code was written.
 func (r *rememberingWriter) WriteHeader(code int) {
 	if r.statusCode == 0 {
 		r.statusCode = code


### PR DESCRIPTION
```
$ curl -s -I -XGET https://api.moov.io/v1/paygate/ping  | grep HTTP
HTTP/1.1 403 Forbidden

$ curl -s -I -XGET -H "Cookie: moov_auth=..." https://api.moov.io/v1/paygate/ping  | grep HTTP
HTTP/1.1 200 OK
```

That checks cookie auth, but oauth2 works too. 