### PR TITLE
http: add x-request-id support with logging and route metrics

### DIFF
--- a/http.go
+++ b/http.go
@@ -114,6 +114,9 @@ func addCORSHandler(r *mux.Router) {
 		w = wrapResponseWriter(w, r, "http")
 		w.Header().Set("Content-Type", "text/plain")
 
+		// Access-Control-Allow-Origin can't be '*' with requests that send credentials.
+		// Instead, we need to explicitly set the domain (from request's Origin header)
+
 		origin := r.Header.Get("Origin")
 		if origin == "" {
 			logger.Log("http", fmt.Sprintf("method=%s, path=%s, preflight - no origin", r.Method, r.URL.Path))
@@ -126,8 +129,8 @@ func addCORSHandler(r *mux.Router) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 		}
 
-		w.Header().Set("Access-Control-Allow-Methods", "HEAD, GET, POST, PATCH, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-CSRFToken,Content-Type,Content-Length,Accept-Encoding,X-User-Id")
+		w.Header().Set("Access-Control-Allow-Methods", "PATCH, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.WriteHeader(http.StatusOK)
 	})

--- a/http_test.go
+++ b/http_test.go
@@ -41,20 +41,20 @@ func TestHTTP__addCORS(t *testing.T) {
 	}
 }
 
-// func TestHTTP__emptyOrigin(t *testing.T) {
-// 	router := mux.NewRouter()
-// 	w := httptest.NewRecorder()
-// 	r := httptest.NewRequest("OPTIONS", "https://api.moov.io/v1/auth/ping", nil)
-// 	r.Header.Set("Origin", "")
+func TestHTTP__emptyOrigin(t *testing.T) {
+	router := mux.NewRouter()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("OPTIONS", "https://api.moov.io/v1/auth/ping", nil)
+	r.Header.Set("Origin", "")
 
-// 	addCORSHandler(router)
-// 	router.ServeHTTP(w, r)
-// 	w.Flush()
+	addCORSHandler(router)
+	router.ServeHTTP(w, r)
+	w.Flush()
 
-// 	if w.Code != http.StatusBadRequest {
-// 		t.Errorf("got %d", w.Code)
-// 	}
-// }
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d", w.Code)
+	}
+}
 
 func TestHTTP__extractCookie(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)

--- a/http_test.go
+++ b/http_test.go
@@ -25,7 +25,7 @@ func TestHTTP__addCORS(t *testing.T) {
 	if w.Code != 200 {
 		t.Errorf("got %d", w.Code)
 	}
-	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "https://moov.io" {
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "*" {
 		t.Errorf("got %q", v)
 	}
 	headers := []string{
@@ -41,20 +41,20 @@ func TestHTTP__addCORS(t *testing.T) {
 	}
 }
 
-func TestHTTP__emptyOrigin(t *testing.T) {
-	router := mux.NewRouter()
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("OPTIONS", "https://api.moov.io/v1/auth/ping", nil)
-	r.Header.Set("Origin", "")
+// func TestHTTP__emptyOrigin(t *testing.T) {
+// 	router := mux.NewRouter()
+// 	w := httptest.NewRecorder()
+// 	r := httptest.NewRequest("OPTIONS", "https://api.moov.io/v1/auth/ping", nil)
+// 	r.Header.Set("Origin", "")
 
-	addCORSHandler(router)
-	router.ServeHTTP(w, r)
-	w.Flush()
+// 	addCORSHandler(router)
+// 	router.ServeHTTP(w, r)
+// 	w.Flush()
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("got %d", w.Code)
-	}
-}
+// 	if w.Code != http.StatusBadRequest {
+// 		t.Errorf("got %d", w.Code)
+// 	}
+// }
 
 func TestHTTP__extractCookie(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://example.com", nil)

--- a/http_test.go
+++ b/http_test.go
@@ -25,7 +25,7 @@ func TestHTTP__addCORS(t *testing.T) {
 	if w.Code != 200 {
 		t.Errorf("got %d", w.Code)
 	}
-	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "*" {
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "https://moov.io" {
 		t.Errorf("got %q", v)
 	}
 	headers := []string{

--- a/login.go
+++ b/login.go
@@ -24,6 +24,7 @@ func addLoginRoutes(router *mux.Router, logger log.Logger, auth authable, userSe
 
 func checkLogin(logger log.Logger, auth authable, userService userRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(w, r, "checkLogin")
 		w.Header().Set("Content-Type", "text/plain")
 
 		cookie := extractCookie(r)
@@ -47,6 +48,8 @@ func checkLogin(logger log.Logger, auth authable, userService userRepository) ht
 
 func loginRoute(logger log.Logger, auth authable, userService userRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(w, r, "loginRoute")
+
 		if r.Body == nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/logout.go
+++ b/logout.go
@@ -17,6 +17,8 @@ func addLogoutRoutes(router *mux.Router, logger log.Logger, auth authable) {
 
 func logoutRoute(auth authable) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(w, r, "logoutRoute")
+
 		cookie := extractCookie(r)
 		if cookie == nil {
 			w.WriteHeader(http.StatusOK)

--- a/main.go
+++ b/main.go
@@ -51,6 +51,10 @@ var (
 		Name: "http_errors",
 		Help: "Count of how many 5xx errors we send out",
 	}, nil)
+	routeHistogram = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Name: "http_response_duration_seconds",
+		Help: "Histogram representing the http response durations",
+	}, []string{"route"})
 
 	clientGenerations = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "oauth2_client_generations",

--- a/oauth.go
+++ b/oauth.go
@@ -93,6 +93,8 @@ func addOAuthRoutes(r *mux.Router, o *oauth, logger log.Logger, auth authable) {
 // authorizeHandler checks the request for appropriate oauth information
 // and returns "200 OK" if the token is valid.
 func (o *oauth) authorizeHandler(w http.ResponseWriter, r *http.Request) {
+	w = wrapResponseWriter(w, r, "oauth.authorizeHandler")
+
 	// We aren't using HandleAuthorizeRequest here because that assumes redirect_uri
 	// exists on the request. We're just checking for a valid token.
 	ti, err := o.server.ValidationBearerToken(r)
@@ -134,6 +136,7 @@ func (r *rememberingWriter) WriteHeader(code int) {
 // generate a token (or return an error).
 func (o *oauth) tokenHandler(w http.ResponseWriter, r *http.Request) {
 	w = &rememberingWriter{ResponseWriter: w}
+	w = wrapResponseWriter(w, r, "oauth.tokenHandler")
 
 	// This block is copied from o.server.HandleTokenRequest
 	// We needed to inspect what's going on a bit.
@@ -176,6 +179,8 @@ func (o *oauth) tokenHandler(w http.ResponseWriter, r *http.Request) {
 // This method extracts the user from the cookies in r.
 func (o *oauth) createClientHandler(auth authable) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(w, r, "oauth.createTokenHandler")
+
 		userId, err := auth.findUserId(extractCookie(r).Value)
 		if err != nil {
 			// user not found, return

--- a/signup.go
+++ b/signup.go
@@ -39,6 +39,8 @@ func addSignupRoutes(router *mux.Router, logger log.Logger, auth authable, userS
 
 func signupRoute(auth authable, userService userRepository) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w = wrapResponseWriter(w, r, "signupRoute")
+
 		if r.Body == nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package main
 
-const Version = "v0.3.0-M4"
+const Version = "v0.3.0-M5"

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package main
 
-const Version = "v0.3.0-M2"
+const Version = "v0.3.0-M3"

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package main
 
-const Version = "v0.3.0-M3"
+const Version = "v0.3.0-M4"


### PR DESCRIPTION
This uses a couple things from `net/http/httptest`, which I like better than how this works over in paygate. 

Thoughts? 