### PR TITLE
http: allow x-request-id and content-type in cors

### DIFF
--- a/http.go
+++ b/http.go
@@ -135,8 +135,8 @@ func setAccessControlAllow(w http.ResponseWriter, r *http.Request) {
 	// Allow requests from anyone's localhost and only from secure pages.
 	if strings.HasPrefix(origin, "http://localhost:") || strings.HasPrefix(origin, "https://") {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Methods", "PATCH, DELETE")
-		w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id")
+		w.Header().Set("Access-Control-Allow-Methods", "PATCH,DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Content-Type", "text/plain")
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -39,7 +39,7 @@ func TestHTTP__addCORS(t *testing.T) {
 	for i := range headers {
 		v := w.Header().Get(headers[i])
 		if v == "" {
-			t.Errorf("%s: %q", headers[i], v)
+			t.Errorf("%s's value is an empty string", headers[i])
 		}
 	}
 }


### PR DESCRIPTION
For the ACH demo I need to POST /v1/ach/files/create with json
for the content type. This isn't allowed by CORS/CORB and so we
can try just allowing it through.

x-request-id is for tracing support in clients.

Issue: https://github.com/moov-io/moov-io/issues/4