### PR TITLE
oauth: split out token check for consolidated auth endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,10 +111,20 @@ func main() {
 		}
 	}()
 
-	oauth, err := setupOauthServer(logger)
+	tokenStore, err := setupOAuthTokenStore(os.Getenv("OAUTH2_TOKENS_DB_PATH"))
 	if err != nil {
-		logger.Log("oauth", err)
-		errs <- err
+		logger.Log("main", fmt.Sprintf("Failed to setup OAuth2 token store: %v", err))
+		os.Exit(1)
+	}
+	clientStore, err := setupOAuthClientStore(os.Getenv("OAUTH2_CLIENTS_DB_PATH"))
+	if err != nil {
+		logger.Log("main", fmt.Sprintf("Failed to setup OAuth2 client store: %v", err))
+		os.Exit(1)
+	}
+	oauth, err := setupOAuthServer(logger, tokenStore, clientStore)
+	if err != nil {
+		logger.Log("main", fmt.Sprintf("Failed to setup OAuth2 service: %v", err))
+		os.Exit(1)
 	}
 	defer func() {
 		if err := oauth.shutdown(); err != nil {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -6,7 +6,17 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"gopkg.in/oauth2.v3"
+	"gopkg.in/oauth2.v3/models"
 )
 
 func TestOAuth2_clientsJSON(t *testing.T) {
@@ -29,5 +39,89 @@ func TestOAuth2_clientsJSON(t *testing.T) {
 	}
 	if clients[0].Domain != "moov.io" {
 		t.Errorf("got %s", clients[0].Domain)
+	}
+}
+
+type testOAuth struct {
+	svc *oauth
+	dir string
+
+	tokenStore oauth2.TokenStore
+}
+
+func (o *testOAuth) cleanup() error {
+	defer os.RemoveAll(o.dir)
+	return o.svc.shutdown()
+}
+
+func createTestOAuth() (*testOAuth, error) {
+	dir, err := ioutil.TempDir("", "auth-oauth")
+	if err != nil {
+		return nil, err
+	}
+
+	tokenStore, err := setupOAuthTokenStore(filepath.Join(dir, "oauth2_tokens.db"))
+	if err != nil {
+		return nil, err
+	}
+	clientStore, err := setupOAuthClientStore(filepath.Join(dir, "oauth2_clients.db"))
+	if err != nil {
+		return nil, err
+	}
+
+	svc, err := setupOAuthServer(log.NewNopLogger(), tokenStore, clientStore)
+	if err != nil {
+		return nil, err
+	}
+
+	return &testOAuth{
+		svc: svc,
+		dir: dir,
+
+		tokenStore: tokenStore,
+	}, nil
+}
+
+func createOAuthToken(t *testing.T, o *testOAuth) *models.Token {
+	t.Helper()
+
+	token := &models.Token{
+		ClientID:        generateID(),
+		Scope:           "read",
+		Access:          generateID(),
+		AccessCreateAt:  time.Now().Add(-1 * time.Second), // in the past
+		AccessExpiresIn: 30 * time.Minute,                 // the future
+	}
+	if err := o.tokenStore.Create(token); err != nil {
+		t.Fatal(err)
+		return nil
+	}
+	return token
+}
+
+func TestOAuth__BearerToken(t *testing.T) {
+	o, err := createTestOAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer o.cleanup()
+
+	// missing header
+	req := httptest.NewRequest("GET", "/users/login", nil)
+	if err := o.svc.requestHasValidOAuthToken(req); err == nil {
+		t.Errorf("expected error, no Authorization header set")
+	}
+
+	// bad header value
+	req.Header.Set("Authorization", "Bearer bad")
+	if err := o.svc.requestHasValidOAuthToken(req); err == nil {
+		t.Errorf("expected error, no bad Authorization data")
+	}
+
+	// happy path
+	token := createOAuthToken(t, o)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.GetAccess()))
+	if err := o.svc.requestHasValidOAuthToken(req); err != nil {
+		t.Errorf("expected no error: %v", err)
 	}
 }


### PR DESCRIPTION
This will let us call `oauth.requestHasValidOAuthToken` on the `*http.Request` inside the new `/v1/auth/check` endpoint, which can also check cookie auth. 

Issue: https://github.com/moov-io/infra/issues/17