### PR TITLE
signup: render JSON content-type back

### DIFF
--- a/signup.go
+++ b/signup.go
@@ -115,7 +115,9 @@ func signupRoute(auth authable, userService userRepository) func(w http.Response
 			}
 
 			// signup worked, yay!
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("{}"))
 
 			// TODO(adam): email approval link and clickthrough
 		} else {


### PR DESCRIPTION
Our OpenAPI generator has a bug where after a successful signup the
response fails decode by the generated client.

The generator has some bugs, but until I can work out what's wrong on
the generation side let's return application/json. Even if the body
won't be parsed.

https://github.com/OpenAPITools/openapi-generator

Fixes: https://github.com/moov-io/go-client/issues/5