### PR TITLE
oauth: send back 403 if OAuth token isn't valid

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -138,6 +138,7 @@ func (o *oauth) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	w = wrapResponseWriter(w, r, "oauth.authorizeHandler")
 
 	if _, err := o.requestHasValidOAuthToken(r); err != nil {
+		w.WriteHeader(http.StatusForbidden)
 		moovhttp.Problem(w, err)
 		return
 	}

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -128,6 +128,25 @@ func TestOAuth__BearerToken(t *testing.T) {
 	}
 }
 
+func TestOAuth__authorizeHandler(t *testing.T) {
+	o, err := createTestOAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer o.cleanup()
+
+	w := httptest.NewRecorder()
+
+	// no token provided
+	req := httptest.NewRequest("GET", "/oauth2/authorize", nil)
+	o.svc.authorizeHandler(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("got %d HTTP status", w.Code)
+	}
+}
+
 func TestOAuth__tokenHandlerNoAuth(t *testing.T) {
 	o, err := createTestOAuth()
 	if err != nil {


### PR DESCRIPTION
During https://github.com/moov-io/api/pull/57 I noticed `auth` sends back a 400, but we really should force a 403 back. 

