### PR TITLE
oauth: add GET /oauth2/clients to get auth'd user client credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.0 (Unreleased)
+
+ADDITIONS
+
+- oauth: Added `GET /oauth2/clients` to retrieve all OAuth2 client credentials for the authenticated user
+
 ## v0.6.0 (Released 2019-02-26)
 
 IMPROVEMENTS

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -192,6 +192,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /oauth2/clients:
+    get:
+      tags:
+        - OAuth2
+      summary: List OAuth2 clients for the authenticated user
+      operationId: getClientsForUserId
+      security:
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/requestId'
+        - $ref: '#/components/parameters/idempotencyKey'
+      responses:
+        '200':
+          description: OAuth2 client credentials
+          content:
+            application/json:
+              schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/OAuth2Clients'
+        '500':
+          description: Internal error occurred, check error(s).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /oauth2/client:
     post:
       tags:
@@ -288,6 +314,10 @@ components:
           description: HTTP domain for OAuth credentials
           type: string
           example: api.moov.io
+    OAuth2Clients:
+      type: array
+      items:
+        $ref: '#/components/schemas/OAuth2Client'
     Login:
       properties:
         email:

--- a/pkg/oauthdb/token.go
+++ b/pkg/oauthdb/token.go
@@ -50,14 +50,10 @@ func NewTokenStoreDB(connString string) (*TokenStore, error) {
 		return nil, fmt.Errorf("problem with Ping against *sql.DB %s: %v", driver, err)
 	}
 
-	tokenStore := &TokenStore{
-		db: db,
-	}
-
+	tokenStore := &TokenStore{db: db}
 	if err := tokenStore.migrate(); err != nil {
 		return nil, err
 	}
-
 	return tokenStore, nil
 }
 


### PR DESCRIPTION
This is needed for moov.io/start so we can list the client credentials on a page for people to copy/paste into their applications.

Issue: https://github.com/moov-io/moov-io/issues/17